### PR TITLE
V0.0.5

### DIFF
--- a/nerea/__init__.py
+++ b/nerea/__init__.py
@@ -8,4 +8,4 @@ from .calculated import *
 
 from .comparisons import *
 
-__version__ = '0.0.4'
+__version__ = '0.0.5'

--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -554,7 +554,7 @@ class SpectralIndex(_Experimental):
         if one_g_xs_ is not None:
             k = self._compute_correction(one_g_xs_)
             v = v - k.value
-            u = np.sqrt(u **2 - k.uncertainty **2)
+            u = np.sqrt(u **2 + k.uncertainty **2)
         else: k = None
         df = _make_df(v, u)
 

--- a/tests/test_SpectralIndex.py
+++ b/tests/test_SpectralIndex.py
@@ -163,7 +163,7 @@ def test_compute_with_correction(si, synthetic_one_g_xs_data):
     u = np.sqrt(vW1 * X1**2 + W1**2 * vX1 + vW2 * X2**2 + W2**2 * vX2)
 
     v_ = 1 - v
-    u_ = np.sqrt(0.06588712284729072 **2 - u **2)
+    u_ = np.sqrt(0.06588712284729072 **2 + u **2)
 
     data = pd.DataFrame({'value': [v_], 'uncertainty': [u_], 'uncertainty [%]': u_ / v_ * 100}, index=['value'])
 


### PR DESCRIPTION
bugfix invariance apportioning:
- `nerea.SpectralIndex.process()` (correction variance was subtracted)
- `test_compute_with_correction`