### PR TITLE
Phspa

### DIFF
--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -185,7 +185,7 @@ class NormalizedFissionFragmentSpectrum(_Experimental):
             with normalization value and uncertainty
         """
         start_time = self.fission_fragment_spectrum.start_time
-        duration = int(self.fission_fragment_spectrum.real_time)
+        duration = self.fission_fragment_spectrum.real_time
         pm = self.power_monitor.average(start_time, duration)
         v, u = ratio_v_u(_make_df(1, 0), pm)
         return _make_df(v, u)

--- a/nerea/reaction_rate.py
+++ b/nerea/reaction_rate.py
@@ -457,7 +457,7 @@ class ReactionRate:
                   experiment_id=experiment_id,
                   detector_id=f"Det {detector}",
                   deposit_id=deposit_id,
-                  timebase=(read['Time'][1] - read['Time'][0]).seconds)
+                  timebase=(read['Time'][1] - read['Time'][0]).total_seconds())
         return out
 
 

--- a/nerea/reaction_rate.py
+++ b/nerea/reaction_rate.py
@@ -73,7 +73,7 @@ class ReactionRate:
                                           absolute_sigma=True)
         return y, popt, pcov, out
 
-    def average(self, start_time: datetime, duration: int) -> pd.DataFrame:
+    def average(self, start_time: datetime, duration: float) -> pd.DataFrame:
         """
         Calculate the average value and uncertainty of a time series data within a specified duration.
 
@@ -81,7 +81,7 @@ class ReactionRate:
         ----------
         start_time : datetime
             The starting time for the data to be analyzed.
-        duration : int
+        duration : float
             The length of time in seconds for which the average is calculated.
 
         Returns


### PR DESCRIPTION
Adapted `nerea.ReactionRate.from_ascii` to read timebins < 1s.
Added test for aveeraging such case.
Adapted `nerea.NormalizedFissionFragmentSpectrum._per_unit_power*` to average power monitor over float duration 