### PR TITLE
Spectral index to Fission fragment spectrum kwargs

### DIFF
--- a/nerea/defaults.py
+++ b/nerea/defaults.py
@@ -1,5 +1,5 @@
 DEFAULT_BIN_KWARGS = {"bins": None, "smooth": True}
 DEFAULT_MAX_KWARGS = {"fst_ch": None}
-DEFAULT_SMOOTH_KWARGS = {"method": 'savgol_filter', "window_length": 10, "polyorder": 4}
+DEFAULT_SMOOTH_KWARGS = {"smoothing_method": 'savgol_filter', "window_length": 10, "polyorder": 4}
 DEFAULT_DTC_KWARGS = {"tau_p": 88e-9, "tau_np": 108e-9}
 DEFAULT_AC_KWARGS = {"t_left": 3e-2, "t_right": 1e-2, "smooth_kwargs": DEFAULT_SMOOTH_KWARGS, "dtc_kwargs": DEFAULT_DTC_KWARGS}

--- a/nerea/effective_mass.py
+++ b/nerea/effective_mass.py
@@ -24,9 +24,9 @@ class EffectiveMass:
             absolute uncertainty.
         """
         data = pd.DataFrame({'nuclide': [self.deposit_id],
-                             'share': [1],
-                             'uncertainty': [0]})
-        return data if self.composition is None else self.composition
+                             'value': [1],
+                             'uncertainty': [0]}).set_index('nuclide')
+        return data if self.composition is None else self.composition.reset_index().set_index('nuclide')[['value', 'uncertainty']]
 
     @property
     def R_channel(self) -> int:

--- a/nerea/reaction_rate.py
+++ b/nerea/reaction_rate.py
@@ -137,13 +137,10 @@ class ReactionRate:
             - "moving average"
             - "savgol_filter"
         """
-        w = False
-        if kwargs.get("method") == 'moving_average':
-            w = kwargs.get("window")
-        elif kwargs.get("method") == 'savgol_filter':
-            w = kwargs.get("window_length")
-        if w and w < self.timebase:  ## if nor window nor window_length are passed w is False
-            raise ValueError("Moving average window length should be larger than the Reaction Rate timebase.")
+        if kwargs.get('window') or kwargs.get('window_lenght'):
+            w = kwargs['window'] if kwargs['smoothing_method'] == 'moving_average' else kwargs['window_length']
+            if w < self.timebase:  ## if nor window nor window_length are passed w is False
+                raise ValueError("Smoothing window length should be larger than the Reaction Rate timebase.")
         else:
             out = pd.DataFrame({"Time": self.data["Time"],
                                 "value": smoothing(self.data["value"], **kwargs)})

--- a/tests/test_ControlRodCalibration.py
+++ b/tests/test_ControlRodCalibration.py
@@ -83,22 +83,22 @@ def test_get_rhos(cr, edd, rrs):
     warnings.filterwarnings("ignore")
 
     rhos = cr._get_rhos(edd,
-                        ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
+                        ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
     pd.testing.assert_frame_equal(rhos.iloc[0].to_frame().T, pd.DataFrame({"value": 0., "uncertainty": 0., "uncertainty [%]": 0.,
                                                                            "h": 0., "VAR_PORT_T": 0., "VAR_PORT_B": 0.,
                                                                            "VAR_PORT_L": 0.}, index=['value']))
     ## Testing formatting: reactivity is tested in test_ReactionRate
-    ref = rrs[60].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'method': 'savgol_filter',
+    ref = rrs[60].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'smoothing_method': 'savgol_filter',
                                                                              'polyorder': 3, 'window_length': 10}
                                                                              ).get_reactivity(edd).assign(h=60.)
     pd.testing.assert_frame_equal(rhos.iloc[1].to_frame().T, ref[["value", "uncertainty", "uncertainty [%]", "h",
                                                                   "VAR_PORT_T", "VAR_PORT_B", "VAR_PORT_L"]])
-    ref = rrs[200].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'method': 'savgol_filter',
+    ref = rrs[200].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'smoothing_method': 'savgol_filter',
                                                                              'polyorder': 3, 'window_length': 10}
                                                                              ).get_reactivity(edd).assign(h=200.)
     pd.testing.assert_frame_equal(rhos.iloc[2].to_frame().T, ref[["value", "uncertainty", "uncertainty [%]", "h",
                                                                    "VAR_PORT_T", "VAR_PORT_B", "VAR_PORT_L"]])
-    ref = rrs[250].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'method': 'savgol_filter',
+    ref = rrs[250].dead_time_corrected().get_asymptotic_counts(smooth_kwargs={'smoothing_method': 'savgol_filter',
                                                                              'polyorder': 3, 'window_length': 10}
                                                                              ).get_reactivity(edd).assign(h=250.)
     pd.testing.assert_frame_equal(rhos.iloc[3].to_frame().T, ref[["value", "uncertainty", "uncertainty [%]", "h",
@@ -112,7 +112,7 @@ def test_differential_curve_no_compensation(dnc, edd_low_uncertainty):
     cols = ['value', 'uncertainty', 'VAR_PORT_T', 'VAR_PORT_B', 'VAR_PORT_L', 'h']
     # not testing uncertainty [%] as there differences with GitHub PC are more visible
     curve = dnc.get_reactivity_curve(edd_low_uncertainty,
-                                     ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
+                                     ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
     pd.testing.assert_frame_equal(curve.iloc[0].to_frame().T[cols],
                                   pd.DataFrame({'value': 4.15633386e-05,
                                                 'uncertainty': 6.85597030e-07,
@@ -128,10 +128,10 @@ def test_integral_curve_no_compensation(inc, edd_low_uncertainty):
     import warnings
     warnings.filterwarnings("ignore")
     curve = inc.get_reactivity_curve(edd_low_uncertainty,
-                                     ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
+                                     ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
     pd.testing.assert_frame_equal(curve,
                                   inc._get_rhos(edd_low_uncertainty,
-                                               ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}}))
+                                               ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}}))
     warnings.filterwarnings("always")
 
 def test_differential_curve_compensation(dc, edd_low_uncertainty):
@@ -140,7 +140,7 @@ def test_differential_curve_compensation(dc, edd_low_uncertainty):
     cols = ['value', 'uncertainty', 'VAR_PORT_T', 'VAR_PORT_B', 'VAR_PORT_L', 'h']
     # not testing uncertainty [%] as there differences with GitHub PC are more visible
     curve = dc.get_reactivity_curve(edd_low_uncertainty,
-                                    ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
+                                    ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
     pd.testing.assert_frame_equal(curve.iloc[0].to_frame().T[cols],
                                   pd.DataFrame({'value': 4.15633386e-05,
                                                 'uncertainty': 6.85597030e-07,
@@ -166,7 +166,7 @@ def test_integral_curve_compensation(ic, edd_low_uncertainty):
     cols = ['value', 'uncertainty', 'VAR_PORT_T', 'VAR_PORT_B', 'VAR_PORT_L', 'h']
     # not testing uncertainty [%] as there differences with GitHub PC are more visible
     curve = ic.get_reactivity_curve(edd_low_uncertainty,
-                                    ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
+                                    ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter', 'polyorder': 3, 'window_length': 10}})
     pd.testing.assert_frame_equal(curve.iloc[0].to_frame().T,
                                   pd.DataFrame({'value': 0., 'uncertainty': 0., 'uncertainty [%]': 0., 'VAR_PORT_T': 0., 'VAR_PORT_B': 0.,
                                                 'VAR_PORT_L': 0., 'h': 0.}, index=['value']))
@@ -194,7 +194,7 @@ def test_get_reactivity_worth(inc, edd_low_uncertainty):
     pd.testing.assert_frame_equal(rw[cols], target[cols], atol=1e-6)
     ## With fitting I get the theoretical value within 1 pcm
     target_rw = inc.get_reactivity_curve(edd_low_uncertainty,
-                                         ac_kwargs={'smooth_kwargs': {'method': 'savgol_filter',
+                                         ac_kwargs={'smooth_kwargs': {'smoothing_method': 'savgol_filter',
                                                                       'polyorder': 3,
                                                                       'window_length': 10}}
                                         ).iloc[1,0]

--- a/tests/test_EffectiveMass.py
+++ b/tests/test_EffectiveMass.py
@@ -15,7 +15,7 @@ def sample_effective_mass():
 def sample_effective_mass_composition():
     deposit_id = "deposit_1"
     detector_id = "detector_1"
-    composition = pd.DataFrame({'nuclide': ['A', 'B'], 'share': [0.8, .2], 'uncertainty': [.01, .02]})
+    composition = pd.DataFrame({'nuclide': ['A', 'B'], 'value': [0.8, .2], 'uncertainty': [.01, .02]})
     integral = pd.DataFrame({'channel': [15, 20, 30], 'value': [10, 20, 30], 'uncertainty': [1, 2, 3]})
     bins = 4096
     return EffectiveMass(deposit_id, detector_id, integral, bins, composition=composition)
@@ -36,8 +36,8 @@ def test_EffectiveMass_properties(sample_effective_mass):
     assert sample_effective_mass.bins == 4096
     pd.testing.assert_frame_equal(sample_effective_mass.composition_,
                                   pd.DataFrame({'nuclide': ['deposit_1'],
-                                                'share': [1],
-                                                'uncertainty': [0]}))
+                                                'value': [1],
+                                                'uncertainty': [0]}).set_index('nuclide'))
 
 def test_EffectiveMass_R_channel_property(sample_effective_mass):
     assert isinstance(sample_effective_mass.R_channel, int)
@@ -46,8 +46,8 @@ def test_EffectiveMass_R_channel_property(sample_effective_mass):
 def test_EffectiveMass_Composition(sample_effective_mass_composition):
     pd.testing.assert_frame_equal(sample_effective_mass_composition.composition_,
                                   pd.DataFrame({'nuclide': ['A', 'B'],
-                                                'share': [0.8, .2],
-                                                'uncertainty': [.01, .02]}))
+                                                'value': [0.8, .2],
+                                                'uncertainty': [.01, .02]}).set_index('nuclide'))
 
 # def test_EffectiveMass_from_xls_classmethod():
 #     file_path = r"tests/Deposit_Detector.xlsx"

--- a/tests/test_NormalizedFissionFragmentSpectrum.py
+++ b/tests/test_NormalizedFissionFragmentSpectrum.py
@@ -91,6 +91,10 @@ def test_get_long_output(nffs):
                                    nffs._get_long_output(nffs.plateau(),
                                                          nffs._time_normalization,
                                                          nffs._power_normalization))
+    pd.testing.assert_frame_equal(expected_df,
+                                   nffs._get_long_output(nffs.plateau(),
+                                                         nffs._time_normalization,
+                                                         nffs._power_normalization, bins=2))
 
 def test_per_unit_mass_R(nffs):
     expected_df = pd.DataFrame({

--- a/tests/test_SpectralIndex.py
+++ b/tests/test_SpectralIndex.py
@@ -51,13 +51,13 @@ def sample_spectrum_2(sample_spectrum_data):
 @pytest.fixture
 def effective_mass_1(sample_integral_data):
     data = pd.DataFrame({'U236': [0.1, 0.01], 'U234': [0.2, 0.02], 'U238': [0.7, 0.07]}).T.reset_index()
-    data.columns = ['nuclide', 'share', 'uncertainty']
+    data.columns = ['nuclide', 'value', 'uncertainty']
     return EffectiveMass(deposit_id="U238", detector_id="C1", data=sample_integral_data, bins=42, composition=data)
 
 @pytest.fixture
 def effective_mass_2(sample_integral_data):
     data = pd.DataFrame({'U234': [0.15, 0.015], 'U238': [0.25, 0.025], 'U235': [0.6, 0.06]}).T.reset_index()
-    data.columns = ['nuclide', 'share', 'uncertainty']
+    data.columns = ['nuclide', 'value', 'uncertainty']
     return EffectiveMass(deposit_id="U235", detector_id="C2", data=sample_integral_data, bins=42, composition=data)
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,5 +132,5 @@ def test_smoothing():
     data = pd.Series([1.,2.,3.,4.,5.,6.,7.,8.,9.,10.,11.,12.,13.])
     ma = smoothing(data)
     pd.testing.assert_series_equal(ma, pd.Series([0.] * 9 + [5.5, 6.5, 7.5, 8.5]))
-    sf = smoothing(data, 'savgol_filter', 2, 1)
+    sf = smoothing(data, smoothing_method='savgol_filter', window_length=2, polyorder=1)
     pd.testing.assert_series_equal(sf, pd.Series([1.] + list(np.arange(2, 13) + 0.5) + [13.]), atol=1e-5)


### PR DESCRIPTION
A bug was found with the `kwargs` not being passed properly down to the pulse height spectrum processing.
This is now fixed with the following approach:
* any wrapped function (e..g. `pandas` or `matplotlib`) takes kwargs filtered through `inspect.signature`;
* all `kwargs` are passed from `NormalizedFissionFragmentSpectrum.process()` to the methoods of `FissionFragmentSpectrum`;
* Calibration with the same `kwargs` requires the user to pass them to the `FissionFragmentSpectrum.calibrate()` method to generate a desired `EffectiveMass` and then also to the `NormalizedFissionFragmentSpectrum.process()` method as well;
* `SpectralIndex.process()` now takes separate `kwargs` for numerator and denominator.