### PR TITLE
plateau kwarg passing fix

### DIFF
--- a/nerea/time_series.py
+++ b/nerea/time_series.py
@@ -6,6 +6,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 import warnings
+from inspect import signature
 
 from .utils import ratio_v_u, _make_df, time_integral_v_u, integral_v_u
 from .functions import get_fit_R2, smoothing, find_plateau
@@ -157,8 +158,7 @@ class Position(TimeSeries):
     Attributes
     ----------
     **data**: ``pd.DataFrame``
-        data frame with time dependent data.
-    """
+        data frame with time dependent data."""
     @property
     def timebase(self):
         return self.data.Time.diff().mean().total_seconds()
@@ -202,8 +202,9 @@ class Position(TimeSeries):
             - ``'ewm'``
             - ``'savgol_filter'`` (requires ``window_length``, ``polyorder``)
             - ``'fit'``(requires ``ch_before_max``, ``order``)"""
+        plateau_kw = {k: v for k, v in kwargs.items() if k in set(signature(find_plateau).parameters)}
         data = self.smooth_data(**kwargs).data if smooth else self.data.copy()
-        return find_plateau(data['Time'], data['value'], **kwargs)
+        return find_plateau(data['Time'], data['value'], **plateau_kw)
 
     def from_plateau(self, **kwargs):
         out = []

--- a/tests/test_Position.py
+++ b/tests/test_Position.py
@@ -50,6 +50,18 @@ def test_plateau(position):
     pd.testing.assert_frame_equal(position.plateau(tol=1,
                                                    absolute_tolerance=False),
                                   plateau)
+    plateau = pd.DataFrame({
+        0: [data["Time"][0], data["Time"][3], 0., 4],
+        1: [data["Time"][4], data["Time"][4], 11., 1],
+        2: [data["Time"][5], data["Time"][6], 20., 2],
+        }, index=["start", "end", "first value", "length"])
+    pd.testing.assert_frame_equal(position.plateau(tol=2,
+                                                   absolute_tolerance=True,
+                                                   smooth=True,
+                                                   smoothing_method='moving_average',
+                                                   window=2,
+                                                   renormalize=False),
+                                  plateau)
 
 
 def test_from_plateau(position):


### PR DESCRIPTION
Fixing kwargs so taht `nerea.functions.smoothing()` and `nerea.functions.find_plateau()` take proper ones when called from `nerea.Position`.