### PR TITLE
Traverse with Position

### DIFF
--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -10,12 +10,14 @@ from .utils import ratio_v_u, product_v_u, _make_df
 from .functions import impurity_correction
 from .constants import ATOMIC_MASS
 from .defaults import *
-from .classes import Xs
+from .classes import Xs, TimeSeriesImporter
 
 import pandas as pd
 import numpy as np
 import warnings
 import matplotlib.pyplot as plt
+from datetime import timedelta
+from inspect import signature
 
 import logging
 
@@ -1201,7 +1203,6 @@ class Traverse(_Experimental):
                 normalization: int|str=None,
                 visual: bool=False,
                 savefig: str='',
-                palette: str='tab10',
                 **kwargs) -> pd.DataFrame:
         """
         ``nerea.Traverse.process()``
@@ -1226,14 +1227,12 @@ class Traverse(_Experimental):
         **savefig** : ``str``, optional
             File name to save the plotted data to.
             Default is `''` for not saving.
-        **palette** : ``str``, optional
-            Color palette to use for plotting.
-            Default is ``'tab10'``.
         **kwargs
             for `nerea.CountRate.plateau()`.
 
             - **sigma** (``int``): standard deviations for plateau finding
             - **timebase** (``int``): time base for integration in plateau search.
+            - **check_count_rate_plateau** (``bool``) consider count rate plateau only.
         
         Returns
         -------
@@ -1243,21 +1242,30 @@ class Traverse(_Experimental):
 
         Note
         ----
-        - Working with ``nerea.CountRates`` instances, the first count rate is used."""
+        - Working with ``nerea.CountRates`` instances, the first count rate is used.
+        - ``normalization`` < 0 is interpreted as no normalization."""
         normalized, m = {}, 0
         # Normalize to power
         for i, (k, rr) in enumerate(self.count_rates.items()):
             n = rr.per_unit_time_power(monitors[i], **kwargs)
             normalized[k] = n if isinstance(rr, CountRate) else list(n.values())[0]
             if normalized[k]['value'].value > m:
-                max_k, m = k, normalized[k].value[0]
-        norm_k = max_k if normalization is None else normalization
+                max_k, m = k, normalized[k].value.iloc[0]
+        if normalization is None:
+            normalization_ = normalized[max_k]
+        elif isinstance(normalization, str) or (isinstance(normalization, int)
+                                                and normalization >= 0):
+            normalization_ = normalized[normalization]
+        elif isinstance(normalization, int) and normalization < 0:
+            normalization_ = _make_df(1, 0)
+        else:
+            raise ValueError(f"Passed invalid normalization value: {normalization}.")
         out = []
         for k, v in normalized.items():
-            out.append(_make_df(*ratio_v_u(v, normalized[norm_k])).assign(traverse=k))
+            out.append(_make_df(*ratio_v_u(v, normalization_)).assign(traverse=k))
         # plot
         if visual or savefig:
-            fig, _ = self.plot(monitors, palette, **kwargs)
+            fig, _ = self.plot(monitors, **kwargs)
             if savefig:
                 fig.savefig(savefig)
                 plt.close()
@@ -1265,7 +1273,6 @@ class Traverse(_Experimental):
 
     def plot(self,
              monitors: Iterable[CountRate| int],
-             palette: str='tab10',
              **kwargs) -> tuple[plt.Figure, Iterable[plt.Axes]]:
         """
         ``nerea.Traverse.plot()``
@@ -1280,9 +1287,6 @@ class Traverse(_Experimental):
             and ``int`` when mapped to ``nerea.CountRates``. The normalization
             is passed to ``CountRate.per_unit_time_power()`` or
             ``CountRates.per_unit_time_power()``.
-        **palette** : ``str``, optional
-            plt palette to use for plotting.
-            Default is ``'tab10'``.
         **kwargs
             for `nerea.CountRate.plateau()`.
             - **sigma** (``int``): standard deviations for plateau finding
@@ -1291,32 +1295,122 @@ class Traverse(_Experimental):
         Returns
         -------
         ``tuple[plt.Figure, Iterable[plt.Axes]]``"""
+        import matplotlib.colors as mcolors
         fig, axs = plt.subplots(len(self.count_rates), 2,
-                              figsize=(15, 30 / len(self.count_rates)))
-        j = 0
+                              figsize=(15, 3 * len(self.count_rates)))
+        colors = plt.cm.hsv(np.linspace(0, 1, len(self.count_rates.keys())))
         for i, (k, rr) in enumerate(self.count_rates.items()):
-            c = plt.get_cmap(palette)(j)
-            plat = rr.plateau(**kwargs)
+            c = mcolors.to_hex(colors[i])
+            use_plateau = kwargs.get('check_count_rate_plateau', False)
+            if use_plateau:
+                kw = {k: v for k, v in kwargs.items() if k in signature(CountRate.plateau)}
+                plat = rr.plateau(**kw)
+            else:
+                plat = rr.data
             dur = (plat.Time.max() - plat.Time.min()).total_seconds()
             # plot data
-            rr.plot(start_time=plat.Time.min(), duration=dur, ax=axs[i][0], c=c)
-            axs[i][0].plot([], [], c=c, label=f"Traverse count rate {k}")
+            rr.plot(start_time=plat.Time.min(), duration=dur, ax=axs[i][0],
+                    c=c, label=f"{i}: {k:.0f} mm")
+            axs[i][0].set_ylabel("Traverse Count Rate [1/s]")
             # plot monitor
-            axs[i][1] = monitors[i].plot(plat.Time.min(), dur, ax=axs[i][1], c=c)
-            axs[i][1].plot([], [], c=c, label=f"Monitor count rate {k}")
-
-            h, l = axs[i][0].get_legend_handles_labels()
-            axs[i][0].legend(h[1:], l[1:])
-            h, l = axs[i][1].get_legend_handles_labels()
-            axs[i][1].legend(h[1:], l[1:])
-
-            j = j + 1 if i < plt.get_cmap(palette).N else 0
+            axs[i][1] = monitors[i].plot(plat.Time.min(), dur, ax=axs[i][1],
+                    c=c, label=f"{i}: {k:.0f} mm")
         return fig, axs
     
     @classmethod
-    def from_countrate_position(count_rate: CountRate, position: Position) -> Self:
-        pass
+    def from_countrate_position(cls,
+                                count_rate: CountRate,
+                                position: Position,
+                                plateau_kw: dict={},
+                                visual: bool=False,
+                                **kwargs) -> Self:
+        """
+        `nerea.Traverse.from_countrate_position()`
+        ------------------------------------------
+        Creates an instance of ``nerea.Traverse`` filtering
+        count rate data on position plateau.
+
+        Parameters
+        ----------
+        **count_rate** : ``nerea.CountRate``
+            count rate data of the traverse.
+        **position** : ``nerea.Position``
+            position data to base the filter on.
+        **plateau_kw** : ``dict``, optional
+            paramters for position plateau search.
+            Default is {}.
+        **visual** : ``bool``, optional
+            flag to visualize the imported data.
+            Default is {}.
+
+        **kwargs
+            additional arguments for class creation
+            - **_enable_checks**: turns consistency checks on/off.
+
+        Returns
+        -------
+        ``nerea.Traverse``
+            with filtered information."""
+        plateau = position.plateau(**plateau_kw)
+        if visual:
+            fig, ax = plt.subplots(figsize=(15, 5), ncols=2)
+            position.plot_data(ax=ax[0])
+            colors = plt.cm.hsv(np.linspace(0, 1, plateau.shape[1]))
+        out = {}
+        for i, p in plateau.T.iterrows():
+            st = p['start']
+            et = p['end'] + timedelta(seconds=position.timebase)
+            d = (et - st).total_seconds()
+            cut = count_rate.cut(st, et)
+            pos = position.average(st, d)['value'].value
+            out[pos] = cut
+            if visual:
+                import matplotlib.colors as mcolors
+                c = mcolors.to_hex(colors[i])
+                position.plot_data(st, d, ax=ax[0], c=c, label=i)
+                cc = 'gray' if i%2 else 'pink'
+                ax[0].axvspan(p['start'], p['end'], alpha=0.5, color=cc)
+                cut.plot(ax=ax[1], c=c)
+        return cls(out, **kwargs)
 
     @classmethod
-    def from_file(filename: str, detector_kwargs: dict={}, position_kwargs={}) -> Self:
-        pass
+    def from_ascii(cls,
+                   file: str,
+                   detector_kw: dict,
+                   position_kw: dict,
+                   plateau_kw: dict={},
+                   visual: bool=False,
+                   **kwargs) -> Self:
+        """
+        `nerea.Traverse.from_countrate_position()`
+        ------------------------------------------
+        Creates an instance of ``nerea.Traverse`` filtering
+        count rate data on position plateau. Reading data from
+        an ASCII file.
+
+        Parameters
+        ----------
+        **file** : ``str``
+            path to the ASCII file.
+        **detector_kw** : ``dict``
+            arguments for ``nerea.TimeSeriesImporter`` to read detector data.
+        **position_kw** : ``dict``
+            arguments for ``nerea.TimeSeriesImporter`` to read position data.
+        **plateau_kw** : ``dict``, optional
+            paramters for position plateau search.
+            Default is {}.
+        **visual** : ``bool``, optional
+            flag to visualize the imported data.
+            Default is {}.
+
+        **kwargs
+            additional arguments for class creation
+            - **_enable_checks**: turns consistency checks on/off.
+
+        Returns
+        -------
+        ``nerea.Traverse``
+            initialized with the data from the ASCII file."""
+        detector = CountRate.from_importer(TimeSeriesImporter.from_ascii(file, **detector_kw))
+        position = Position.from_importer(TimeSeriesImporter.from_ascii(file, **position_kw))
+        return cls.from_countrate_position(detector, position, plateau_kw, visual, **kwargs)

--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -1,10 +1,11 @@
 import serpentTools as sts  ## impurity correction
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Self
 
 from .pulse_height_spectrum import PulseHeightSpectrum
 from .effective_mass import EffectiveMass
-from .time_series import CountRate, CountRates
+from .time_series import CountRate, CountRates, Position
 from .utils import ratio_v_u, product_v_u, _make_df
 from .functions import impurity_correction
 from .constants import ATOMIC_MASS
@@ -1311,3 +1312,11 @@ class Traverse(_Experimental):
 
             j = j + 1 if i < plt.get_cmap(palette).N else 0
         return fig, axs
+    
+    @classmethod
+    def from_countrate_position(count_rate: CountRate, position: Position) -> Self:
+        pass
+
+    @classmethod
+    def from_file(filename: str, detector_kwargs: dict={}, position_kwargs={}) -> Self:
+        pass

--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -1139,6 +1139,7 @@ class SpectralIndex(_Experimental):
                                     )
         return pd.concat([df, self._get_long_output(num, den, k)], axis=1)
 
+
 @dataclass(slots=True)
 class Traverse(_Experimental):
     """

--- a/nerea/functions.py
+++ b/nerea/functions.py
@@ -447,10 +447,11 @@ def find_plateau(x: Iterable,
     -------
     ``pd.DataFrame``
         data frame with time and counts columns."""
-    tol_ = tol if absolute_tolerance else tol * y[1:]
-    dy = np.abs(np.diff(y))
+    x_, y_ = np.array(x), np.array(y)
+    tol_ = tol if absolute_tolerance else tol * y_[1:]
+    dy = np.abs(np.diff(y_))
     change_idx = np.where(dy > tol_)[0] + 1
-    idx = np.concatenate(([0], change_idx, [len(y)]))
+    idx = np.concatenate(([0], change_idx, [len(y_)]))
     starts = idx[:-1]
     ends = idx[1:]
     plateaus = []
@@ -459,9 +460,10 @@ def find_plateau(x: Iterable,
         length = e - s
         if length >= min_length:
             plateaus.append(pd.DataFrame({
-                "start": x[s],
-                "end": x[e - 1],
-                "first value": y[s],
+                "start": x_[s],
+                "end": x_[e - 1],
+                "first value": y_[s],
+                "mean value": np.mean(y_[s : e]),
                 "length": length
             }, index=[i]).T)
             i += 1

--- a/nerea/time_series.py
+++ b/nerea/time_series.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "TimeSeries",
+    "Position",
     "CountRate",
     "CountRates"]
 
@@ -136,11 +137,11 @@ class TimeSeries:
         if experiment_time:
             data.Time = range(data.Time.shape[0])
         ax = data.plot(x="Time",
-                        y='value',
-                        ax=ax,
-                        color=c,
-                        kind='scatter',
-                        **kwargs)
+                       y='value',
+                       ax=ax,
+                       color=c,
+                       kind='scatter',
+                       **kwargs)
         return ax
 
     def average(self,
@@ -194,14 +195,13 @@ class TimeSeries:
         v, u = time_integral_v_u(series)
         delta = (series.Time.iloc[-1] - series.Time.iloc[0]).total_seconds()
         v /= delta
-        if uncertainty == 'poisson':
+        uncertainty_ = 'std' if v <= 0 else uncertainty
+        if uncertainty_ == 'poisson':
             u /= delta
-        elif uncertainty == 'std':
+        elif uncertainty_ == 'std':
             # time_integral_v_u ignores last point
             u = np.std(series['value'][:-1], ddof=1)
-            print('$$$$$')
-            print(series['value'])
-        elif uncertainty == 'sem':
+        elif uncertainty_ == 'sem':
         # time_integral_v_u ignores last point
             u = np.std(series['value'][:-1], ddof=1
                        ) / np.sqrt(np.size(series['value']) - 1)
@@ -218,7 +218,7 @@ class TimeSeries:
 
     @classmethod
     def from_importer(cls, importer: TimeSeriesImporter):
-        return cls(importer.data)
+        return cls(importer.data, importer.metadata['timebase'])
 
 
 @dataclass(slots=True)
@@ -279,10 +279,9 @@ class Position(TimeSeries):
     def from_plateau(self, **kwargs):
         out = []
         for i, p in self.plateau(**kwargs).T.iterrows():
-            out.append(self.cut_data(p['start'],
-                                     p['end'] + timedelta(seconds=self.timebase)
-                                     ).data.assign(PLATEAU=i))
-            
+            cut = self.cut_data(p['start'],
+                                p['end'] + timedelta(seconds=self.timebase))
+            out.append(cut.data.assign(PLATEAU=i))
         return self.__class__(pd.concat(out, ignore_index=True), timebase=self.timebase)
 
 
@@ -476,7 +475,7 @@ class CountRate(TimeSeries):
             with ``'Time'`` and ``'value'`` columns."""
         time = self.data.Time.min()
         plateau_start_time, plateau_end_time = self.data.Time.min(), self.data.Time.min()
-        sum, max = 1, 0
+        sum, max = 1, -1
         while time < self.data.Time.max():
             # compute the integral over timebase
             time_plus_timedelta = time + timedelta(seconds=timebase)
@@ -537,7 +536,7 @@ class CountRate(TimeSeries):
             out.append(self.cut(p['start'], p['end'] + timedelta(seconds=self.timebase)))
         return out
 
-    def per_unit_power(self, monitor: Self, **kwargs) -> pd.DataFrame:
+    def per_unit_power(self, monitor: Self, check_count_rate_plateau: bool=True, **kwargs) -> pd.DataFrame:
         """
         `nerea.CountRate.per_unit_power()`
         ----------------------------------
@@ -547,6 +546,9 @@ class CountRate(TimeSeries):
         ----------
         **monitor** : ``nerea.CountRate``
             The power monitor for the count rate normalization.
+        **check_count_rate_plateau** : ``bool``, optional
+            flag to define whether to check for count rate plateau to
+            compute the traverse or not. Default is ``True``.
         **kwargs
             arguments for ``self.plateau()``.
             - **sigma** (``int``): standard deviations for plateau finding.
@@ -555,13 +557,20 @@ class CountRate(TimeSeries):
         Returns
         -------
         ``pd.DataFrame``
-            with ``'value'`` and ``'uncertainty'`` columns."""
-        plateau = self.plateau(**kwargs)
+            with ``'value'`` and ``'uncertainty'`` columns.
+            
+        Notes
+        -----
+        ``kwargs`` ignored if ``check_count_rate_plateau == False``."""
+        if check_count_rate_plateau:
+            plateau = self.plateau(**kwargs)
+        else:
+            plateau = self.data
         duration = (plateau.Time.max() - plateau.Time.min()).seconds
         normalization = monitor.average(plateau.Time.min(), duration) 
         return _make_df(*ratio_v_u(_make_df(*integral_v_u(plateau.value)), normalization))
 
-    def per_unit_time_power(self, monitor: Self, *args, **kwargs) -> pd.DataFrame:
+    def per_unit_time_power(self, monitor: Self, check_count_rate_plateau: bool=True, *args, **kwargs) -> pd.DataFrame:
         """
         `nerea.CountRate.per_unit_time_power()`
         ---------------------------------------
@@ -570,8 +579,11 @@ class CountRate(TimeSeries):
 
         Parameters
         ----------
-        monitor : CountRate
+        **monitor** : CountRate
             The power monitor for the count rate normalization.
+        **check_count_rate_plateau** : ``bool``, optional
+            flag to define whether to check for count rate plateau to
+            compute the traverse or not. Default is ``True``.
         
         Parameters
         ----------
@@ -585,10 +597,17 @@ class CountRate(TimeSeries):
         Returns
         -------
         ``pd.DataFrame``
-            with ``'value'`` and ``'uncertainty'`` columns."""
-        plateau = self.plateau(*args, **kwargs)
+            with ``'value'`` and ``'uncertainty'`` columns.
+            
+        Notes
+        -----
+        ``kwargs`` ignored if ``check_count_rate_plateau == False``."""
+        if check_count_rate_plateau:
+            plateau = self.plateau(**kwargs)
+        else:
+            plateau = self.data
         duration = (plateau.Time.max() - plateau.Time.min()).seconds
-        unit_p = self.per_unit_power(monitor, *args, **kwargs)
+        unit_p = self.per_unit_power(monitor, check_count_rate_plateau, *args, **kwargs)
         return _make_df(unit_p.value / duration, unit_p.uncertainty / duration)
 
     def dead_time_corrected(self, tau_p: float = 88e-9, tau_np: float = 108e-9) -> Self:
@@ -807,7 +826,7 @@ class CountRate(TimeSeries):
                             ax,
                             c,
                             **kwargs)
-        if not experiment_time:
+        if not experiment_time and self._vlines:
             for v in self._vlines:
                 ax.axvline(v, ls='--', c='gray', label="File joining")
             ax.legend()

--- a/nerea/time_series.py
+++ b/nerea/time_series.py
@@ -151,7 +151,7 @@ class TimeSeries:
 class Position(TimeSeries):
     """
     ``nerea.Position``
-    ====================
+    ==================
     Class to handle time dependent position data.
     Inherits from ``nerea.TimeSeries``.
 
@@ -173,7 +173,7 @@ class Position(TimeSeries):
 
         Parameters
         ----------
-        **smooth** : bool
+        **smooth** : ``bool``
             flag to smooth the data before plateau search.
             Default is ``False``.
 
@@ -480,6 +480,42 @@ class CountRate(TimeSeries):
         if plateau_end_time == self.data.Time.min():
             raise Exception(f"No plateau found in for detector {self.detector_id} in experiment {self.experiment_id}.")
         return self.data.query("Time > @max_plateau_start_time and Time <= @max_plateau_end_time")
+
+    def filter_on_position_plateau(self, position: Position, **kwargs) -> list[Self]:
+        """
+        `nerea.CountRate.filter_on_position_plateau()`
+        ----------------------------------------------
+        Filters the count rate data based on plateau found on
+        a `nerea.Position` instance.
+
+        Parameters
+        ----------
+        **position** : ``nerea.Position``
+            the position based on which plateau the data should
+            be filtered.
+
+        **kwargs
+        - **smooth** (``bool``) flag smoothing position data before plateau search.
+        Additional arguments for
+            
+            - ``nerea.functions.find_plateau()``
+                - **tol** (``float``) tolerance for plateau finding.
+                - **absolute_tolerance** (``bool``) flag for absolute ``tol``.
+                - **min_length** (``int``) minimal number of bins in plateau.
+
+            - ``nerea.functions.smoothing()``
+                - **renormalize** (``bool``): Whether to renormalize the data.
+                - **smoothing_method** (``str``): The mehtod to implement for smoothing.
+                - arguments for the chosen ``nerea.functions.smoothing``.
+        
+        Returns
+        -------
+        ``list[nere.CountRate]``
+            corresponding to the different plateau."""
+        out = []
+        for _, p in position.plateau(**kwargs).T.iterrows():
+            out.append(self.cut(p['start'], p['end'] + timedelta(seconds=self.timebase)))
+        return out
 
     def per_unit_power(self, monitor: Self, **kwargs) -> pd.DataFrame:
         """

--- a/nerea/time_series.py
+++ b/nerea/time_series.py
@@ -37,6 +37,7 @@ class TimeSeries:
         data frame with time dependent data.
     """
     data: pd.DataFrame
+    timebase: float  # seconds
 
     def smooth_data(self, **kwargs) -> Self:
         """
@@ -67,7 +68,7 @@ class TimeSeries:
         kw = DEFAULT_SMOOTH_KWARGS | kwargs
         out = pd.DataFrame({"Time": self.data["Time"],
                             "value": smoothing(self.data["value"], **kw)})
-        return TimeSeries(data=out)
+        return TimeSeries(data=out, timebase=self.timebase)
 
     def cut_data(self, start: datetime, end: datetime) -> Self:
         """
@@ -91,7 +92,7 @@ class TimeSeries:
         -----
         Left boundary included, right boundary excluded."""
         data = self.data.query("Time >= @start and Time < @end")
-        return TimeSeries(data)
+        return TimeSeries(data, timebase=self.timebase)
 
     def plot_data(self,
         start_time: datetime=None,
@@ -142,6 +143,79 @@ class TimeSeries:
                         **kwargs)
         return ax
 
+    def average(self,
+                start_time: datetime,
+                duration: float,
+                uncertainty: str='poisson') -> pd.DataFrame:
+        """
+        `nerea.TimeSeries.average()`
+        ---------------------------
+        Calculates the average value and uncertainty of
+        time series data within a specified duration.
+
+        Parameters
+        ----------
+        **start_time** : ``datetime.datetime``
+            The starting time for the data to be analyzed.
+        **duration** : ``float``
+            The length of time in seconds for which
+            the average is calculated.
+        **uncertainty** : ``str``, optional
+            policy for uncertainty calculation.
+            Available options are:
+            - ``'poisson'``
+            - ``'std'``
+            - ``'sem'``
+            Default is ``'poisson'``.
+
+        Returns
+        -------
+        ``pd.DataFrame``
+            data frame containing average `'value'` and `'uncertainty'` columns.
+
+        Notes
+        -----
+        - uncertainty computed assuming Poisson distribution: 1/sqrt(`value`)
+            
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> data = pd.DataFrame({'Time': pd.date_range('2021-01-01', periods=100, freq='S'),
+                                 'value': np.random.rand(100)})
+        >>> pm = CountRate(data=data, start_time=datetime(2021, 1, 1), 
+                              campaign_id='C1', experiment_id='E1', detector_id='M1')
+        >>> avg_df = pm.average(datetime(2021, 1, 1, 0, 0, 30), 10)
+        >>> print(avg_df)"""
+        # end_time should be 1 timebase after the real end time to use
+        end_time = start_time + timedelta(seconds=duration + self.timebase)
+        series = self.cut_data(start_time, end_time).data
+        if series.empty:
+            raise ValueError("No time series data in the requested interval.")
+        v, u = time_integral_v_u(series)
+        delta = (series.Time.iloc[-1] - series.Time.iloc[0]).total_seconds()
+        v /= delta
+        if uncertainty == 'poisson':
+            u /= delta
+        elif uncertainty == 'std':
+            # time_integral_v_u ignores last point
+            u = np.std(series['value'][:-1], ddof=1)
+            print('$$$$$')
+            print(series['value'])
+        elif uncertainty == 'sem':
+        # time_integral_v_u ignores last point
+            u = np.std(series['value'][:-1], ddof=1
+                       ) / np.sqrt(np.size(series['value']) - 1)
+        else:
+            raise ValueError(f"'{uncertainty}' is not an allowed uncertainty policy.")
+        relative = True if v != 0 else False
+        # Time Normalization of the Average
+        # If the RR time binning is not 1 s, there is a chance the query truncated
+        # the time series so that the difference between first and last time in
+        # `series` are closer than duration. Hence I define delta.
+        # iloc[-1] explained by the use of time_integral_v_u(): we stop at the 
+        # beginning of the next step-post time stamp.
+        return _make_df(v, u, relative)
+
     @classmethod
     def from_importer(cls, importer: TimeSeriesImporter):
         return cls(importer.data)
@@ -158,11 +232,7 @@ class Position(TimeSeries):
     Attributes
     ----------
     **data**: ``pd.DataFrame``
-        data frame with time dependent data."""
-    @property
-    def timebase(self):
-        return self.data.Time.diff().mean().total_seconds()
-    
+        data frame with time dependent data."""    
     def plateau(self,
                 smooth: bool=False,
                 **kwargs) -> pd.DataFrame:
@@ -212,7 +282,8 @@ class Position(TimeSeries):
             out.append(self.cut_data(p['start'],
                                      p['end'] + timedelta(seconds=self.timebase)
                                      ).data.assign(PLATEAU=i))
-        return self.__class__(pd.concat(out, ignore_index=True))
+            
+        return self.__class__(pd.concat(out, ignore_index=True), timebase=self.timebase)
 
 
 @dataclass(slots=True)
@@ -247,13 +318,11 @@ class CountRate(TimeSeries):
     _vlines: ``Iterable[datetime]``, optional
         lines to draw plotting. Handled internally.
         Default is ``[]``."""
-    data: pd.DataFrame
     start_time: datetime
     campaign_id: str
     experiment_id: str
     detector_id: str
     deposit_id: str
-    timebase: float = 1. ## in seconds
     _dead_time_corrected: bool = False
     _vlines: Iterable[datetime] = field(default_factory=lambda: [])
 
@@ -301,55 +370,6 @@ class CountRate(TimeSeries):
                                           full_output=True,
                                           absolute_sigma=False)  # sigma scaled to math sample variance
         return y, popt, pcov, out
-
-    def average(self, start_time: datetime, duration: float) -> pd.DataFrame:
-        """
-        `nerea.CountRate.average()`
-        ---------------------------
-        Calculates the average value and uncertainty of
-        time series data within a specified duration.
-
-        Parameters
-        ----------
-        **start_time** : ``datetime.datetime``
-            The starting time for the data to be analyzed.
-        **duration** : ``float``
-            The length of time in seconds for which
-            the average is calculated.
-
-        Returns
-        -------
-        ``pd.DataFrame``
-            data frame containing average `'value'` and `'uncertainty'` columns.
-
-        Notes
-        -----
-        - uncertainty computed assuming Poisson distribution: 1/sqrt(`value`)
-            
-        Examples
-        --------
-        >>> from datetime import datetime
-        >>> data = pd.DataFrame({'Time': pd.date_range('2021-01-01', periods=100, freq='S'),
-                                 'value': np.random.rand(100)})
-        >>> pm = CountRate(data=data, start_time=datetime(2021, 1, 1), 
-                              campaign_id='C1', experiment_id='E1', detector_id='M1')
-        >>> avg_df = pm.average(datetime(2021, 1, 1, 0, 0, 30), 10)
-        >>> print(avg_df)"""
-        # end_time should be 1 timebase after the real end time to use
-        end_time = start_time + timedelta(seconds=duration + self.timebase)
-        series = self.cut(start_time, end_time).data
-        if series.empty:
-            raise ValueError("No count rate data in the requested interval.")
-        v, u = time_integral_v_u(series)
-        relative = True if v != 0 else False
-        # Time Normalization of the Average
-        # If the RR time binning is not 1 s, there is a chance the query truncated
-        # the time series so that the difference between first and last time in
-        # `series` are closer than duration. Hence I define delta.
-        # iloc[-1] explained by the use of time_integral_v_u(): we stop at the 
-        # beginning of the next step-post time stamp.
-        delta = (series.Time.iloc[-1] - series.Time.iloc[0]).total_seconds()
-        return _make_df(v / delta, u / delta, relative)
 
     def smooth(self, **kwargs) -> Self:
         """
@@ -605,12 +625,12 @@ class CountRate(TimeSeries):
                                                         dead_time_correction(n, x, tau_p, tau_np),
                                                         x))
         return self.__class__(pm,
-                              self.start_time,
-                              self.campaign_id,
-                              self.experiment_id,
-                              self.detector_id,
-                              self.deposit_id,
-                              self.timebase,
+                              start_time=self.start_time,
+                              campaign_id=self.campaign_id,
+                              experiment_id=self.experiment_id,
+                              detector_id=self.detector_id,
+                              deposit_id=self.deposit_id,
+                              timebase=self.timebase,
                               _dead_time_corrected=True)
 
     def cut(self, start: datetime, end: datetime) -> Self:

--- a/nerea/utils.py
+++ b/nerea/utils.py
@@ -54,10 +54,8 @@ def time_integral_v_u(s: pd.DataFrame) -> tuple[float, float]:
     Notes
     -----
     - ``s`` is assumed to be steps-post and the data are treated accordingly,
-        hence ``s`` should end 1 time step after the desired end of integration.
-        To allow calculation of time differences, s should start 1 time spep
-        before the desired start time."""
-    v = (s.value * s.Time.diff().shift(-1).apply(lambda x: x.total_seconds())).sum()
+        hence ``s`` should end 1 time step after the desired end of integration."""
+    v = (s.value * s.Time.diff().shift(-1).dt.total_seconds()).sum()
     u = np.sqrt(v)
     return v, u
 

--- a/tests/test_Comparison.py
+++ b/tests/test_Comparison.py
@@ -61,7 +61,7 @@ def effective_mass_2(sample_integral_data):
 
 @pytest.fixture
 def power_monitor(sample_power_monitor_data):
-        return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep')
+        return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr_1(fission_fragment_spectrum_1, effective_mass_1, power_monitor):
@@ -131,33 +131,33 @@ counts = [0,0,0,0,0,.3,.3,.4,.1,.2,.5,0,.0,1,1,1.5,2,2.5,2,3,3.5,4,4.2,3.8,4.2,3
 def rr1():
     time = [datetime(2024,5,27,13,19,20) + timedelta(seconds=i) for i in range(len(counts))]
     data =  pd.DataFrame({'Time': time, 'value': counts})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr2():
     time = [datetime(2024,5,27,15,12,42) + timedelta(seconds=i) for i in range(len(counts))]
     data = pd.DataFrame({'Time': time, 'value': np.array(counts) / 2})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor1(rr1):
     data_ = rr1.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor2(rr2):
     data_ = rr2.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def sample_traverse_rr(rr1, rr2):

--- a/tests/test_ControlRodCalibration.py
+++ b/tests/test_ControlRodCalibration.py
@@ -43,7 +43,8 @@ def rrs(periods):
                                     experiment_id="TEST01",
                                     detector_id="DET",
                                     deposit_id="DEP",
-                                    _dead_time_corrected=True).cut(ts, te)
+                                    _dead_time_corrected=True,
+                                    timebase=1.).cut(ts, te)
     return counts
 
 @pytest.fixture

--- a/tests/test_CountRate.py
+++ b/tests/test_CountRate.py
@@ -18,7 +18,7 @@ def sample_data():
 @pytest.fixture
 def power_monitor(sample_data):
     return CountRate(data=sample_data, campaign_id="C1", experiment_id="E1",
-                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep')
+                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def sample_data_02s():
@@ -45,7 +45,7 @@ def sample_data_uncertain_time_binning():
 @pytest.fixture
 def power_monitor_uncertain_time_binning(sample_data_uncertain_time_binning):
     return CountRate(data=sample_data_uncertain_time_binning, campaign_id="C1", experiment_id="E1",
-                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep')
+                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def plateau_data():
@@ -91,17 +91,17 @@ def plateau_data():
 
 @pytest.fixture
 def rr_plateau(plateau_data):
-    return CountRate(plateau_data, plateau_data.Time.min(),
+    return CountRate(plateau_data, start_time=plateau_data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def plateau_monitor(plateau_data):
     data_ = plateau_data.copy()
     data_.value = [15000] * len(data_.value)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def dtc_monitor():
@@ -113,7 +113,7 @@ def dtc_monitor():
         experiment_id="TEST_DTC_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=1
+        timebase=1.
     )
 
 @pytest.fixture
@@ -126,7 +126,7 @@ def linear_monitor():
         experiment_id="TEST_LINEAR_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=1
+        timebase=1.
     )
 
 @pytest.fixture
@@ -186,7 +186,7 @@ def exponential_monitor():
         experiment_id="TEST_EXPONENTIAL_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=10,
+        timebase=10.,
         _dead_time_corrected=True  # here I assume it to me already corrected to ease the testing
     )
 
@@ -201,7 +201,7 @@ def cut_exponential_monitor(exponential_monitor):
         experiment_id="TEST_EXPONENTIAL_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=10,
+        timebase=10.,
         _dead_time_corrected=True  # here I assume it to me already corrected to ease the testing
     )
 
@@ -223,7 +223,7 @@ def linear_monitor():
         experiment_id="TEST_LINEAR_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=1
+        timebase=1.
     )
 
 @pytest.fixture
@@ -283,7 +283,7 @@ def exponential_monitor():
         experiment_id="TEST_EXPONENTIAL_MONITOR",
         detector_id="A",
         deposit_id="U235",
-        timebase=10,
+        timebase=10.,
         _dead_time_corrected=True  # here I assume it to me already corrected to ease the testing
     )
 
@@ -335,7 +335,7 @@ def test_filter_on_position_plateau(power_monitor):
     position = Position(pd.DataFrame({
         'Time': [datetime(2024, 5, 19, 20, 5, 0) + timedelta(seconds=i) for i in range(7)],
         'value': [1, 1, 1, 15, 20, 20, 20]
-    }))
+    }), timebase=1.)
     result = power_monitor.filter_on_position_plateau(position, tol=1, absolute_tolerance=True, min_length=2)
     test = [pd.DataFrame({'Time': [datetime(2024, 5, 19, 20, 5, 0) + timedelta(seconds=i) for i in range(3)],
                           'value': [0, 10, 15]}),

--- a/tests/test_CountRate.py
+++ b/tests/test_CountRate.py
@@ -85,7 +85,7 @@ def plateau_data():
           3.7,3.8,3.9,4,4,4.2,4.1,3.5,3.2,3,2.5,2.2,2,2,1.5,1.5,1.6,1,1,1,
           .5,.6,.4,.3,.5,.3,.5,.6,.1,.3,.2,.1,0,0,0,0,0,0,0,
           3.7,3.8,3.9,4,4,4.2,4.1,3.5,3.2,3,2.5,2.2,2,2,1.5,1.5,1.6,1,1,1,
-          .5,.6,.4,.3,.5,.3,.5,.6,.1,.3,.2,.1,0,0,0,0,0,0,0,]
+          .5,.6,.4,.3,.5,.3,.5,.6,.1,.3,.2,.1,0,0,0,0,0,0,0]
     time = [datetime(2024,5,27,13,19,20) + timedelta(seconds=i) for i in range(len(counts))]
     return pd.DataFrame({'Time': time, 'value': counts})
 
@@ -351,6 +351,11 @@ def test_per_unit_power(rr_plateau, plateau_monitor):
                                 'uncertainty [%]': 0.06783245}, index=['value'])
     pd.testing.assert_frame_equal(expected_df, rr_plateau.per_unit_power(plateau_monitor))
 
+    expected_df = pd.DataFrame({'value': 572.8164866666667,
+                                'uncertainty': 0.2892491432525306,
+                                'uncertainty [%]': 0.050495952889856394}, index=['value'])
+    pd.testing.assert_frame_equal(expected_df, rr_plateau.per_unit_power(plateau_monitor, check_count_rate_plateau=False))
+
 def test_per_unit_time_power(rr_plateau, plateau_monitor):
     MIN_T = datetime(2024,5,27,13,21,1)
     MAX_T = datetime(2024,5,27,13,24,20)
@@ -359,6 +364,12 @@ def test_per_unit_time_power(rr_plateau, plateau_monitor):
     target = rr_plateau.per_unit_time_power(plateau_monitor)
     assert np.isclose(target.value.values[0], V, atol=0.00001)
     assert np.isclose(target.uncertainty.values[0], U, atol=0.00001)
+    expected_df = pd.DataFrame({'value': 1.190887,
+                                'uncertainty': 0.000601,
+                                'uncertainty [%]': 0.050496}, index=['value'])
+    pd.testing.assert_frame_equal(expected_df, rr_plateau.per_unit_time_power(plateau_monitor,
+                                                                              check_count_rate_plateau=False),
+                                    atol=1e-5, check_exact=False)
 
 def test_smooth(plateau_monitor):
     # individual smoothings tested in test_utils.py

--- a/tests/test_CountRate.py
+++ b/tests/test_CountRate.py
@@ -2,7 +2,7 @@ import pytest
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
-from nerea.time_series import CountRate
+from nerea.time_series import CountRate,  Position
 from nerea.classes import EffectiveDelayedParams
 from nerea.classes import EffectiveDelayedParams
 from nerea.utils import _make_df
@@ -330,6 +330,20 @@ def test_plateau_timebase(rr_plateau):
     assert rr_plateau.plateau(2, timebase=7).Time.min() == MIN_T
     assert rr_plateau.plateau(2, timebase=7).Time.max() == MAX_T
     assert rr_plateau.plateau(2, timebase=7).value.sum() == COUNTS
+
+def test_filter_on_position_plateau(power_monitor):
+    position = Position(pd.DataFrame({
+        'Time': [datetime(2024, 5, 19, 20, 5, 0) + timedelta(seconds=i) for i in range(7)],
+        'value': [1, 1, 1, 15, 20, 20, 20]
+    }))
+    result = power_monitor.filter_on_position_plateau(position, tol=1, absolute_tolerance=True, min_length=2)
+    test = [pd.DataFrame({'Time': [datetime(2024, 5, 19, 20, 5, 0) + timedelta(seconds=i) for i in range(3)],
+                          'value': [0, 10, 15]}),
+            pd.DataFrame({'Time': [datetime(2024, 5, 19, 20, 5, 4) + timedelta(seconds=i) for i in range(3)],
+                          'value': [20, 15, 10]}, index=[4, 5, 6])]
+    assert len(test) == len(result)
+    for i, j in zip(result, test):
+        pd.testing.assert_frame_equal(i.data, j)
 
 def test_per_unit_power(rr_plateau, plateau_monitor):
     expected_df = pd.DataFrame({'value': 532.84,

--- a/tests/test_CountRates.py
+++ b/tests/test_CountRates.py
@@ -23,12 +23,12 @@ def sample_data2():
 @pytest.fixture
 def power_monitor_1(sample_data1):
     return CountRate(data=sample_data1, campaign_id="C1", experiment_id="E1",
-                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep')
+                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def power_monitor_2(sample_data2):
     return CountRate(data=sample_data2, campaign_id="C1", experiment_id="E1",
-                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep')
+                        start_time=datetime(2024, 5, 19, 20, 5, 0), detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def pms(power_monitor_1, power_monitor_2):
@@ -78,17 +78,17 @@ def plateau_data():
 
 @pytest.fixture
 def rr_plateau(plateau_data):
-    return CountRate(plateau_data, plateau_data.Time.min(),
+    return CountRate(plateau_data, start_time=plateau_data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def plateau_monitor(plateau_data):
     data_ = plateau_data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 3000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 def test_deposit_id(pms, power_monitor_1):
     assert pms.deposit_id == power_monitor_1.deposit_id

--- a/tests/test_CoverE.py
+++ b/tests/test_CoverE.py
@@ -60,7 +60,7 @@ def effective_mass_2(sample_integral_data):
 
 @pytest.fixture
 def power_monitor(sample_power_monitor_data):
-        return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep')
+        return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr_1(fission_fragment_spectrum_1, effective_mass_1, power_monitor):
@@ -126,31 +126,31 @@ counts = [0,0,0,0,0,.3,.3,.4,.1,.2,.5,0,.0,1,1,1.5,2,2.5,2,3,3.5,4,4.2,3.8,4.2,3
 def rr1():
     time = [datetime(2024,5,27,13,19,20) + timedelta(seconds=i) for i in range(len(counts))]
     data =  pd.DataFrame({'Time': time, 'value': counts})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr2():
     time = [datetime(2024,5,27,15,12,42) + timedelta(seconds=i) for i in range(len(counts))]
     data = pd.DataFrame({'Time': time, 'value': np.array(counts) / 2})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor1(rr1):
     data_ = rr1.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor2(rr2):
     data_ = rr2.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
                         detector_id=2, deposit_id='dep')
 

--- a/tests/test_NormalizedPulseHeightSpectrum.py
+++ b/tests/test_NormalizedPulseHeightSpectrum.py
@@ -65,7 +65,7 @@ def effective_mass_one_lld(sample_integral_data_one_lld):
 @pytest.fixture
 def power_monitor(sample_power_monitor_data):
         return CountRate(experiment_id="B", data=sample_power_monitor_data,
-                            start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep')
+                            start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def nffs(phs, effective_mass, power_monitor):

--- a/tests/test_Position.py
+++ b/tests/test_Position.py
@@ -14,7 +14,7 @@ def sample_data():
 
 @pytest.fixture
 def position(sample_data):
-    return Position(sample_data)
+    return Position(sample_data, timebase=1.)
 
 def test_timebase(position):
     assert position.timebase == 1
@@ -22,39 +22,39 @@ def test_timebase(position):
 def test_plateau(position):
     data = position.data
     plateau = pd.DataFrame({
-        0: [data["Time"][0], data["Time"][2], 1, 3],
-        1: [data["Time"][3], data["Time"][3], 2, 1],
-        2: [data["Time"][4], data["Time"][6], 20, 3],
-    }, index=["start", "end", "first value", "length"])
+        0: [data["Time"][0], data["Time"][2], 1, 1, 3],
+        1: [data["Time"][3], data["Time"][3], 2, 2, 1],
+        2: [data["Time"][4], data["Time"][6], 20, 20, 3],
+    }, index=["start", "end", "first value", "mean value","length"])
     pd.testing.assert_frame_equal(position.plateau(tol=0,
                                                    absolute_tolerance=True),
                                   plateau)
     plateau = pd.DataFrame({
-        0: [data["Time"][0], data["Time"][2], 1, 3],
-        1: [data["Time"][4], data["Time"][6], 20, 3],
-    }, index=["start", "end", "first value", "length"])
+        0: [data["Time"][0], data["Time"][2], 1, 1, 3],
+        1: [data["Time"][4], data["Time"][6], 20, 20, 3],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(position.plateau(tol=0,
                                                    min_length=2,
                                                    absolute_tolerance=True),
                                   plateau)
     plateau = pd.DataFrame({
-        0: [data["Time"][0], data["Time"][3], 1, 4],
-        1: [data["Time"][4], data["Time"][6], 20, 3],
-    }, index=["start", "end", "first value", "length"])
+        0: [data["Time"][0], data["Time"][3], 1, 1.25, 4],
+        1: [data["Time"][4], data["Time"][6], 20, 20., 3],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(position.plateau(tol=1,
                                                    absolute_tolerance=True),
                                   plateau)
     plateau = pd.DataFrame({
-        0: [data["Time"][0], data["Time"][6], 1, 7],
-        }, index=["start", "end", "first value", "length"])
+        0: [data["Time"][0], data["Time"][6], 1, 9.28571428571, 7],
+        }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(position.plateau(tol=1,
                                                    absolute_tolerance=False),
                                   plateau)
     plateau = pd.DataFrame({
-        0: [data["Time"][0], data["Time"][3], 0., 4],
-        1: [data["Time"][4], data["Time"][4], 11., 1],
-        2: [data["Time"][5], data["Time"][6], 20., 2],
-        }, index=["start", "end", "first value", "length"])
+        0: [data["Time"][0], data["Time"][3], 0., 0.875, 4],
+        1: [data["Time"][4], data["Time"][4], 11., 11., 1],
+        2: [data["Time"][5], data["Time"][6], 20., 20., 2],
+        }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(position.plateau(tol=2,
                                                    absolute_tolerance=True,
                                                    smooth=True,

--- a/tests/test_PulseHeightSpectrum.py
+++ b/tests/test_PulseHeightSpectrum.py
@@ -214,7 +214,7 @@ def test_calibrate(sample_spectrum):
                              experiment_id="CALIBRATION 1",
                              detector_id='test',
                              deposit_id="U235",
-                             timebase= 1)
+                             timebase=1.)
     k, uk = 8720., 0.02 * 8720.
     m, um = 27000, 51.96152422706632
     c, uc = 3.815094702900616e-09, 2.562134210123782e-12

--- a/tests/test_SpectralIndex.py
+++ b/tests/test_SpectralIndex.py
@@ -63,7 +63,7 @@ def effective_mass_2(sample_integral_data):
 
 @pytest.fixture
 def power_monitor(sample_power_monitor_data):
-    return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep')
+    return CountRate(experiment_id="B", data=sample_power_monitor_data, start_time=datetime(2024, 5, 29, 12, 25, 10), campaign_id='C', detector_id='M', deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr_1(sample_spectrum_1, effective_mass_1, power_monitor):

--- a/tests/test_TimeSeries.py
+++ b/tests/test_TimeSeries.py
@@ -15,7 +15,7 @@ def sample_data():
 
 @pytest.fixture
 def ts(sample_data):
-    return TimeSeries(sample_data)
+    return TimeSeries(sample_data, timebase=1.)
 
 def test_smooth_data(ts):
     # the logic of this is tested in test_functions
@@ -31,3 +31,26 @@ def test_cut_data(ts):
     cut = ts.cut_data(st, et)
     assert isinstance(cut, TimeSeries)
     pd.testing.assert_frame_equal(cut.data, ts.data.query("Time >= @st and Time < @et"))
+
+def test_average(ts):
+    st = datetime(2024, 5, 19, 20, 5, 0)
+    result = ts.average(st, 3)
+    v, u = 1., np.sqrt(3) / 3
+    test = pd.DataFrame({'value': v,
+                         'uncertainty': u,
+                         'uncertainty [%]': u * 100}, index=['value'])
+    pd.testing.assert_frame_equal(result, test)
+
+    result = ts.average(st, 3, uncertainty='std')
+    v, u = 1., np.std([0, 1, 2], ddof=1)
+    test = pd.DataFrame({'value': v,
+                         'uncertainty': u,
+                         'uncertainty [%]': u * 100}, index=['value'])
+    pd.testing.assert_frame_equal(result, test)
+
+    result = ts.average(st, 3, uncertainty='sem')
+    v, u = 1., np.std([0, 1, 2], ddof=1) / np.sqrt(3)
+    test = pd.DataFrame({'value': v,
+                         'uncertainty': u,
+                         'uncertainty [%]': u * 100}, index=['value'])
+    pd.testing.assert_frame_equal(result, test)

--- a/tests/test_Traverse.py
+++ b/tests/test_Traverse.py
@@ -45,33 +45,33 @@ counts = [0,0,0,0,0,.3,.3,.4,.1,.2,.5,0,.0,1,1,1.5,2,2.5,2,3,3.5,4,4.2,3.8,4.2,3
 def rr1():
     time = [datetime(2024,5,27,13,19,20) + timedelta(seconds=i) for i in range(len(counts))]
     data =  pd.DataFrame({'Time': time, 'value': counts})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def rr2():
     time = [datetime(2024,5,27,15,12,42) + timedelta(seconds=i) for i in range(len(counts))]
     data = pd.DataFrame({'Time': time, 'value': np.array(counts) / 2})
-    return CountRate(data, data.Time.min(),
+    return CountRate(data, start_time=data.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=1, deposit_id='dep')
+                        detector_id=1, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor1(rr1):
     data_ = rr1.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def monitor2(rr2):
     data_ = rr2.data.copy()
     data_.value = data_.value.apply(lambda x: 600 if x > 1000 else 1)
-    return CountRate(data_, data_.Time.min(),
+    return CountRate(data_, start_time=data_.Time.min(),
                         campaign_id='A', experiment_id='B',
-                        detector_id=2, deposit_id='dep')
+                        detector_id=2, deposit_id='dep', timebase=1.)
 
 @pytest.fixture
 def sample_traverse_rr(rr1, rr2):

--- a/tests/test_Traverse.py
+++ b/tests/test_Traverse.py
@@ -90,3 +90,13 @@ def test_process(sample_traverse_rr, monitor1, monitor2, sample_traverse_rrs):
     pd.testing.assert_frame_equal(expected_df, sample_traverse_rr.process([monitor1,
                                                                            monitor2]))
     pd.testing.assert_frame_equal(expected_df, sample_traverse_rrs.process([2, 2]))
+
+    # test normalizations
+    pd.testing.assert_frame_equal(expected_df, sample_traverse_rrs.process([2, 2], normalization=None))
+    pd.testing.assert_frame_equal(expected_df, sample_traverse_rrs.process([2, 2], normalization='loc A'))
+    # no normalization
+    expected_df_ = pd.DataFrame({'value': [6.648846960167715, 3.3163627152988853],
+                                'uncertainty': [0.02308856634367043, 0.00851562256284556],
+                                'uncertainty [%]': [0.3472566970181553, 0.25677597096245536],
+                                'traverse': ['loc A', 'loc B']})
+    pd.testing.assert_frame_equal(expected_df_, sample_traverse_rrs.process([2, 2], normalization=-1))

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -346,8 +346,8 @@ def test_find_plateau():
 
     result = find_plateau(x, y, tol=0, min_length=1)
     plateau = pd.DataFrame({
-        0: [x[0], x[-1], 10, 5],
-    }, index=["start", "end", "first value", "length"])
+        0: [x[0], x[-1], 10, 10., 5],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test multiple plateaus
@@ -355,12 +355,12 @@ def test_find_plateau():
     y = np.array([1, 1, 2, 2, 2, 5, 5, 1])
 
     result = find_plateau(x, y, tol=0, min_length=1)
-    plateau = plateau = pd.DataFrame({
-        0: [x[0], x[1], 1, 2],
-        1: [x[2], x[4], 2, 3],
-        2: [x[5], x[6], 5, 2],
-        3: [x[7], x[7], 1, 1],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[0], x[1], 1, 1., 2],
+        1: [x[2], x[4], 2, 2., 3],
+        2: [x[5], x[6], 5, 5., 2],
+        3: [x[7], x[7], 1, 1., 1],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
 
     # test relative tolerance
@@ -369,11 +369,13 @@ def test_find_plateau():
     result = find_plateau(x, y, tol=0.01, min_length=1, absolute_tolerance=False)
     pd.testing.assert_frame_equal(result, find_plateau(x, y, tol=0, min_length=1))
     result = find_plateau(x, y, tol=0.5, min_length=1, absolute_tolerance=False)
-    plateau = plateau = pd.DataFrame({
-        0: [x[0], x[4], 1, 5],
-        1: [x[5], x[6], 5, 2],
-        2: [x[7], x[7], 1, 1],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[0], x[4], 1, 1.6, 5],
+        1: [x[5], x[6], 5, 5., 2],
+        2: [x[7], x[7], 1, 1., 1],
+    }, index=["start", "end", "first value", "mean value", "length"])
+    print("###########")
+    print(result)
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test min length filter
@@ -381,9 +383,9 @@ def test_find_plateau():
     y = np.array([1, 1, 2, 2, 2, 5, 5, 1])
 
     result = find_plateau(x, y, tol=0, min_length=3)
-    plateau = plateau = pd.DataFrame({
-        0: [x[2], x[4], 2, 3],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[2], x[4], 2, 2., 3],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test tolerance merging
@@ -391,9 +393,9 @@ def test_find_plateau():
     y = np.array([10, 10.01, 10.02, 10.0, 10.01, 10])
 
     result = find_plateau(x, y, tol=0.05, min_length=1)
-    plateau = plateau = pd.DataFrame({
-        0: [x[0], x[5], 10., 6],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[0], x[5], 10., y.mean(), 6],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
     
     ## test single point plateaus
@@ -401,12 +403,12 @@ def test_find_plateau():
     y = np.array([1, 2, 3, 4])
 
     result = find_plateau(x, y, tol=0, min_length=1)
-    plateau = plateau = pd.DataFrame({
-        0: [x[0], x[0], 1, 1],
-        1: [x[1], x[1], 2, 1],
-        2: [x[2], x[2], 3, 1],
-        3: [x[3], x[3], 4, 1],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[0], x[0], 1, 1., 1],
+        1: [x[1], x[1], 2, 2., 1],
+        2: [x[2], x[2], 3, 3., 1],
+        3: [x[3], x[3], 4, 4., 1],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test non uniform x
@@ -414,10 +416,10 @@ def test_find_plateau():
     y = np.array([5, 5, 5, 2, 2])
 
     result = find_plateau(x, y, tol=0, min_length=1)
-    plateau = plateau = pd.DataFrame({
-        0: [x[0], x[2], 5, 3],
-        1: [x[3], x[4], 2, 2],
-    }, index=["start", "end", "first value", "length"])
+    plateau = pd.DataFrame({
+        0: [x[0], x[2], 5, 5., 3],
+        1: [x[3], x[4], 2, 2., 2],
+    }, index=["start", "end", "first value", "mean value", "length"])
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test noise stability


### PR DESCRIPTION
Now `nerea.Traverse` instances can be initiated from `nerea.CountRate` synchronous to `nerea.Position` instances.
Minor adaptations to the processing are made following the feedback from processing VALUE traverses.