### PR TITLE
Traverse with postion uncertainty

### DIFF
--- a/nerea/calculated.py
+++ b/nerea/calculated.py
@@ -204,7 +204,7 @@ class CalculatedTraverse(_Calculated):
         out = []
         for d in detector_names:
             v, u = sts.read(file).detectors[d].bins[0][-2:]
-            out.append(_make_df(v, u * v).assign(traverse=d))
+            out.append(_make_df(v, u * v).assign(position=d))
         out = pd.concat(out)
         return cls(data=out, **kwargs)
 
@@ -225,10 +225,10 @@ class CalculatedTraverse(_Calculated):
         ``pd.DataFrame``
             data frame containing C `'value'` and `'uncertainty'` columns."""
         out = []
-        max_d = self.data.query("value == @self.data.value.max()").traverse.iloc[0]
+        max_d = self.data.query("value == @self.data.value.max()").position.iloc[0]
         norm_d = max_d if normalization is None else normalization
-        den = self.data.query('traverse == @norm_d')
+        den = self.data.query('position == @norm_d')
         den = _make_df(den.value.iloc[0], den.uncertainty.iloc[0])
         num = _make_df(self.data.value, self.data.uncertainty)
-        out = _make_df(*ratio_v_u(num, den)).assign(traverse=self.data.traverse.values)
+        out = _make_df(*ratio_v_u(num, den)).assign(position=self.data.position.values)
         return out.reset_index(drop=True)

--- a/nerea/comparisons.py
+++ b/nerea/comparisons.py
@@ -165,14 +165,15 @@ class _Comparison:
         -------
         ``pd.DataFrame``
             the C/E value and uncertainty"""
-        n = self.num.calculate(normalization=normalization).set_index('traverse')
-        d = self.den.process(normalization=normalization, **kwargs).set_index('traverse')
+        n = self.num.calculate(normalization=normalization).set_index('position')
+        d = self.den.process(normalization=normalization, **kwargs).set_index('position')
         v, u = ratio_v_u(n, d)
         if not _minus_one_percent:
             out = _make_df(v, u, idx=v.index)
         else:
             out = _make_df((v - 1) * 100 , u * 100, relative=False, idx=v.index)
-        return out.reset_index(names='traverse')[['value', 'uncertainty', 'uncertainty [%]', 'traverse']]
+        out = out.reset_index(names='position').assign(position_uncertainty=d.position_uncertainty)
+        return out[['value', 'uncertainty', 'uncertainty [%]', 'position', 'position_uncertainty']]
 
     def compute(self, _minus_one_percent: bool=False, normalization: str =None,
                 **kwargs) -> pd.DataFrame:

--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -1158,9 +1158,15 @@ class Traverse(_Experimental):
         ``key`` is the position identifier, ``value`` is the 
         corresponding ``nerea.CountRate`` or `nerea`.CountRates``.
         If ``nerea.CountRates``, the first is considered.
+    **position_uncertainty** : ``Iterable[float] | None``, optional
+        ``count_rates.keys()``-long iterable with the uncertainty
+        of each position.
+        Defaults to ``None`` for ``np.nan`` uncertainty at each
+        position.
     _enable_checks: ``bool``, optoinal
         flag enabling consistency checks. Default is ``True``."""
     count_rates: dict[str, CountRate | CountRates]
+    position_uncertainty: Iterable[float] | None=None
     _enable_checks: bool = True
     
     def __post_init__(self):
@@ -1238,7 +1244,7 @@ class Traverse(_Experimental):
         -------
         ``pd.DataFrame``
             with ``'value'``, ``'uncertainty'``, ``'uncertainty [%]'`` and
-            ``'traverse'`` columns.
+            ``'position'`` columns.
 
         Note
         ----
@@ -1262,14 +1268,21 @@ class Traverse(_Experimental):
             raise ValueError(f"Passed invalid normalization value: {normalization}.")
         out = []
         for k, v in normalized.items():
-            out.append(_make_df(*ratio_v_u(v, normalization_)).assign(traverse=k))
+            out.append(_make_df(*ratio_v_u(v, normalization_)).assign(position=k))
         # plot
         if visual or savefig:
             fig, _ = self.plot(monitors, **kwargs)
             if savefig:
                 fig.savefig(savefig)
                 plt.close()
-        return pd.concat(out, ignore_index=True)
+        if self.position_uncertainty is None:
+            up = [np.nan] * len(self.count_rates.keys())
+        elif len(self.position_uncertainty) != len(self.count_rates.keys()):
+            warnings.warn("`position_uncertainty` does not match the size of `count_rates`.")
+            up = [np.nan] * len(self.count_rates.keys())
+        else:
+            up = self.position_uncertainty
+        return pd.concat(out, ignore_index=True).assign(position_uncertainty=up)
 
     def plot(self,
              monitors: Iterable[CountRate| int],
@@ -1350,19 +1363,27 @@ class Traverse(_Experimental):
         Returns
         -------
         ``nerea.Traverse``
-            with filtered information."""
+            with filtered information.
+        
+        Notes
+        -----
+        ``self.position_uncertainty`` computed as standard error of
+        position data."""
         plateau = position.plateau(**plateau_kw)
         if visual:
             fig, ax = plt.subplots(figsize=(15, 5), ncols=2)
             position.plot_data(ax=ax[0])
             colors = plt.cm.hsv(np.linspace(0, 1, plateau.shape[1]))
         out = {}
+        up = []
         for i, p in plateau.T.iterrows():
             st = p['start']
             et = p['end'] + timedelta(seconds=position.timebase)
             d = (et - st).total_seconds()
             cut = count_rate.cut(st, et)
-            pos = position.average(st, d)['value'].value
+            avg = position.average(st, d, uncertainty='sem')
+            pos = avg['value'].value
+            up.append(avg['uncertainty'].value)
             out[pos] = cut
             if visual:
                 import matplotlib.colors as mcolors
@@ -1371,7 +1392,7 @@ class Traverse(_Experimental):
                 cc = 'gray' if i%2 else 'pink'
                 ax[0].axvspan(p['start'], p['end'], alpha=0.5, color=cc)
                 cut.plot(ax=ax[1], c=c)
-        return cls(out, **kwargs)
+        return cls(out, np.array(up), **kwargs)
 
     @classmethod
     def from_ascii(cls,

--- a/tests/test_CalculatedTraverse.py
+++ b/tests/test_CalculatedTraverse.py
@@ -5,7 +5,7 @@ from nerea.calculated import CalculatedTraverse
 @pytest.fixture
 def sample_data():
     return pd.DataFrame({'value': [1, 2], 'uncertainty': [.5, .5],
-                         'uncertainty [%]': [50, 25], 'traverse': ['A', 'B']}, index=['value','value'])
+                         'uncertainty [%]': [50, 25], 'position': ['A', 'B']}, index=['value','value'])
 
 @pytest.fixture
 def sample_c(sample_data):
@@ -20,5 +20,5 @@ def test_calculate(sample_c):
     target_df = pd.DataFrame({'value': [0.5,  1],
                               'uncertainty': [0.279508, 0.353553],
                               'uncertainty [%]': [55.901699, 35.355339],
-                              'traverse': ['A', 'B']})
+                              'position': ['A', 'B']})
     pd.testing.assert_frame_equal(target_df, sample_c.calculate())

--- a/tests/test_Comparison.py
+++ b/tests/test_Comparison.py
@@ -167,7 +167,7 @@ def sample_traverse_rr(rr1, rr2):
 def sample_c_traverse_data():
     return pd.DataFrame({'value': [1.01, 0.5],
                          'uncertainty': [0.01, 0.01],
-                         'traverse': ['loc A', 'loc B']})
+                         'position': ['loc A', 'loc B']})
 
 @pytest.fixture
 def sample_c_traverse(sample_c_traverse_data):
@@ -210,7 +210,8 @@ def test_compute_traverse(sample_ce_traverse, monitor1, monitor2):
     expected_df = pd.DataFrame({'value': [1., 0.99250555],
                                 'uncertainty': [0.01483835, 0.02256028],
                                 'uncertainty [%]': [1.48383507, 2.27306339],
-                                'traverse': ['loc A', 'loc B']})
+                                'position': ['loc A', 'loc B'],
+                                'position_uncertainty': [np.nan] * 2})
     pd.testing.assert_frame_equal(expected_df, sample_ce_traverse.compute(monitors=[monitor1, monitor2]))
 
 def test_minus_one_per_cent(sample_si_ce):

--- a/tests/test_Traverse.py
+++ b/tests/test_Traverse.py
@@ -86,7 +86,8 @@ def test_process(sample_traverse_rr, monitor1, monitor2, sample_traverse_rrs):
     expected_df = pd.DataFrame({'value': [1.        , 0.49878764],
                                 'uncertainty': [0.00491095, 0.00215417],
                                 'uncertainty [%]': [0.49109513, 0.4318809],
-                                'traverse': ['loc A', 'loc B']})
+                                'position': ['loc A', 'loc B'],
+                                'position_uncertainty': [np.nan] * 2})
     pd.testing.assert_frame_equal(expected_df, sample_traverse_rr.process([monitor1,
                                                                            monitor2]))
     pd.testing.assert_frame_equal(expected_df, sample_traverse_rrs.process([2, 2]))
@@ -98,5 +99,6 @@ def test_process(sample_traverse_rr, monitor1, monitor2, sample_traverse_rrs):
     expected_df_ = pd.DataFrame({'value': [6.648846960167715, 3.3163627152988853],
                                 'uncertainty': [0.02308856634367043, 0.00851562256284556],
                                 'uncertainty [%]': [0.3472566970181553, 0.25677597096245536],
-                                'traverse': ['loc A', 'loc B']})
+                                'position': ['loc A', 'loc B'],
+                                'position_uncertainty': [np.nan] * 2})
     pd.testing.assert_frame_equal(expected_df_, sample_traverse_rrs.process([2, 2], normalization=-1))


### PR DESCRIPTION
- `nerea.Traverse` now has a `position_uncertaitny` attribute to handle position uncertainty
- `nerea.Traverse.process()` and `nerea.CalculatedTraverse.calculate()` now use `'position'` as column name rather than `'traverse'`
- Information on position uncertainty is propagated to `nerea.Comparison.compute()`