### PR TITLE
Plateau skip

### DIFF
--- a/nerea/functions.py
+++ b/nerea/functions.py
@@ -421,7 +421,9 @@ def find_plateau(x: Iterable,
                  y: Iterable,
                  tol: float=1e-2,
                  absolute_tolerance: bool=False,
-                 min_length: int=1) -> pd.DataFrame:
+                 min_length: int=1,
+                 skip_l: int=0,
+                 skip_r: int=0) -> pd.DataFrame:
     """
     `nerea.functions.find_plateau()`
     --------------------------------
@@ -431,32 +433,44 @@ def find_plateau(x: Iterable,
     ----------
     **x**  : ``Iterable``
         x axis of x-y series.
-    **y**  : ``Iterable``
+    **y**  : ``Iterable``, optional
         y axis of x-y series.
     **tol** : ``float|None``
         tolerance for plateau finding (absolute or relative).
         Default is ``1e-2``.
-    **absolute_tolerance** : ``bool``
+    **absolute_tolerance** : ``bool``, optional
         flag defining whether ``tol`` is absolute or not.
         Default is ``False``.
-    **min_length** : ``int``
+    **min_length** : ``int``, optional
         minimal number of bins to consider in a plateau.
         Default is 1.
+    **skip_l** : ``int``, optional
+        bins to discard after plateau beginning.
+        Default is 0.
+    **skip_r** : ``int``, optional
+        bins to discard before plateau end.
+        Default is 0.    
 
     Returns
     -------
     ``pd.DataFrame``
-        data frame with time and counts columns."""
+        data frame with time and counts columns.
+        
+    Notes
+    -----
+    - ``min_lenght`` is considered for the final plateau,
+    after skipping left and right."""
     x_, y_ = np.array(x), np.array(y)
     tol_ = tol if absolute_tolerance else tol * y_[1:]
     dy = np.abs(np.diff(y_))
     change_idx = np.where(dy > tol_)[0] + 1
     idx = np.concatenate(([0], change_idx, [len(y_)]))
-    starts = idx[:-1]
-    ends = idx[1:]
+    starts = idx[:-1] + skip_l
+    ends = idx[1:] - skip_r
     plateaus = []
     i = 0
     for s, e in zip(starts, ends):
+        # negative length if skip makes them exchange -> no plateau
         length = e - s
         if length >= min_length:
             plateaus.append(pd.DataFrame({

--- a/nerea/time_series.py
+++ b/nerea/time_series.py
@@ -234,6 +234,8 @@ class Position(TimeSeries):
     **data**: ``pd.DataFrame``
         data frame with time dependent data."""    
     def plateau(self,
+                skip_left: float=0.,
+                skip_right: float=0.,
                 smooth: bool=False,
                 **kwargs) -> pd.DataFrame:
         """
@@ -243,7 +245,13 @@ class Position(TimeSeries):
 
         Parameters
         ----------
-        **smooth** : ``bool``
+        **skip_left** : ``float``, optional
+            seconds to skip from begining of plateau.
+            Default is ``0.``.
+        **skip_right** : ``float``, optional
+            seconds to skip from end of plateau.
+            Default is ``0.``.
+        **smooth** : ``bool``, optional
             flag to smooth the data before plateau search.
             Default is ``False``.
 
@@ -273,6 +281,14 @@ class Position(TimeSeries):
             - ``'savgol_filter'`` (requires ``window_length``, ``polyorder``)
             - ``'fit'``(requires ``ch_before_max``, ``order``)"""
         plateau_kw = {k: v for k, v in kwargs.items() if k in set(signature(find_plateau).parameters)}
+        if plateau_kw.get('skip_l', False):
+            warnings.warn(f"Double value passed for `skip_l`, using {plateau_kw.get('skip_l')}")
+        else:
+            plateau_kw['skip_l'] = int(np.floor(skip_left / self.timebase))
+        if plateau_kw.get('skip_r', False):
+            warnings.warn(f"Double value passed for `skip_r`, using {plateau_kw.get('skip_r')}")
+        else:
+            plateau_kw['skip_r'] = int(np.floor(skip_right / self.timebase))
         data = self.smooth_data(**kwargs).data if smooth else self.data.copy()
         return find_plateau(data['Time'], data['value'], **plateau_kw)
 

--- a/tests/test_Position.py
+++ b/tests/test_Position.py
@@ -13,13 +13,26 @@ def sample_data():
     return data
 
 @pytest.fixture
+def sample_data_2s_timebase():
+    data = pd.DataFrame({
+        'Time': [datetime(2024, 5, 19, 20, 5, 0) + timedelta(seconds=i * 2) for i in range(7)],
+        'value': [1, 1, 1, 2, 20, 20, 20]
+    })
+    return data
+
+@pytest.fixture
 def position(sample_data):
     return Position(sample_data, timebase=1.)
 
-def test_timebase(position):
-    assert position.timebase == 1
+@pytest.fixture
+def position_2s_timebase(sample_data_2s_timebase):
+    return Position(sample_data_2s_timebase, timebase=2.)
 
-def test_plateau(position):
+def test_timebase(position, position_2s_timebase):
+    assert position.timebase == 1
+    assert position_2s_timebase.timebase == 2
+
+def test_plateau(position, position_2s_timebase):
     data = position.data
     plateau = pd.DataFrame({
         0: [data["Time"][0], data["Time"][2], 1, 1, 3],
@@ -61,6 +74,31 @@ def test_plateau(position):
                                                    smoothing_method='moving_average',
                                                    window=2,
                                                    renormalize=False),
+                                  plateau)
+    
+    # test skip_left and skip_right
+    data = position_2s_timebase.data
+    plateau = pd.DataFrame({
+        0: [data["Time"][1], data["Time"][1], 1, 1, 1],
+        1: [data["Time"][5], data["Time"][5], 20, 20, 1],
+    }, index=["start", "end", "first value", "mean value","length"])
+    pd.testing.assert_frame_equal(position_2s_timebase.plateau(
+                                                tol=0,
+                                                absolute_tolerance=True,
+                                                skip_left=2, # seconds = 1 bin
+                                                skip_right=2),
+                                  plateau)
+    # np.floor() applied if fractional bins need to be skipped
+    data = position_2s_timebase.data
+    plateau = pd.DataFrame({
+        0: [data["Time"][1], data["Time"][2], 1, 1, 2],
+        1: [data["Time"][5], data["Time"][6], 20, 20, 2],
+    }, index=["start", "end", "first value", "mean value","length"])
+    pd.testing.assert_frame_equal(position_2s_timebase.plateau(
+                                                tol=0,
+                                                absolute_tolerance=True,
+                                                skip_left=2, # seconds = 1 bin
+                                                skip_right=1),
                                   plateau)
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -432,3 +432,34 @@ def test_find_plateau():
 
     # should detect one big plateau
     assert result.shape[1] == 1
+
+    # test skip left and right
+    x = np.arange(5)
+    y = np.array([10, 10, 10, 10, 10])
+
+    result = find_plateau(x, y, tol=0, min_length=1, skip_l=1)
+    plateau = pd.DataFrame({
+        0: [x[0] + 1, x[-1], 10, 10., 4],
+    }, index=["start", "end", "first value", "mean value", "length"])
+    pd.testing.assert_frame_equal(result, plateau)
+
+    result = find_plateau(x, y, tol=0, min_length=1, skip_r=1)
+    plateau = pd.DataFrame({
+        0: [x[0], x[-1] - 1, 10, 10., 4],
+    }, index=["start", "end", "first value", "mean value", "length"])
+    pd.testing.assert_frame_equal(result, plateau)
+
+    result = find_plateau(x, y, tol=0, min_length=1, skip_l=1, skip_r=1)
+    plateau = pd.DataFrame({
+        0: [x[0] + 1, x[-1] - 1, 10, 10., 3],
+    }, index=["start", "end", "first value", "mean value", "length"])
+    pd.testing.assert_frame_equal(result, plateau)
+
+    x = np.arange(15)
+    y = np.array([10] * 5 + [20] * 10)
+    result = find_plateau(x, y, tol=0, min_length=1, skip_l=3, skip_r=3)
+    plateau = pd.DataFrame({
+        0: [x[5] + 3, x[-1] - 3, 20, 20., 4],
+    }, index=["start", "end", "first value", "mean value", "length"])
+    # skips the first plateau (len 5) as I discard +3 and -3 elements
+    pd.testing.assert_frame_equal(result, plateau)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -374,8 +374,6 @@ def test_find_plateau():
         1: [x[5], x[6], 5, 5., 2],
         2: [x[7], x[7], 1, 1., 1],
     }, index=["start", "end", "first value", "mean value", "length"])
-    print("###########")
-    print(result)
     pd.testing.assert_frame_equal(result, plateau)
 
     ## test min length filter


### PR DESCRIPTION
Position plateau data can now be filtered by a few seconds left and/or right.
- `nerea.functions.find_plateau()` adapted to this logic (works with indices)
- `nerea.Position.plateau()` takes skip times in seconds and converts them to bins to wrap `nerea.functions.find_plateau()`