### PR TITLE
MassNormalized_2_AtomicMassNormalized_kwargs

### DIFF
--- a/nerea/classes.py
+++ b/nerea/classes.py
@@ -70,7 +70,7 @@ class Xs:
     ----------
     **data**: ``pd.DataFrame``
         data frame with cross section data (index is nuclide identifier).
-    **mass_normalized**: ``bool``, optional
+    **atomic_mass_normalized**: ``bool``, optional
         whether the cross section is mass-normalized.
         Default is `False`.
     **volume_normalized**: ``bool``, optional
@@ -79,7 +79,7 @@ class Xs:
     **volume**: ``float``, optional
         volume for volume normalization. Default is `1.0`."""
     data : pd.DataFrame
-    mass_normalized : bool=False
+    atomic_mass_normalized : bool=False
     volume_normalized : bool=False
     volume: float = 1.
 
@@ -94,7 +94,7 @@ class Xs:
         -------
         `nerea.Xs`"""
         return self.__class__(self.data.copy(),
-                              self.mass_normalized,
+                              self.atomic_mass_normalized,
                               self.volume_normalized,
                               self.volume)
 
@@ -118,7 +118,7 @@ class Xs:
         **args, **kwargs
             Additional arguments for instance creation
             
-            - **mass_normalized** (``bool``, optional), whether the cross section is mass-normalized.
+            - **atomic_mass_normalized** (``bool``, optional), whether the cross section is mass-normalized.
             - **volume_normalized** (``bool``, optional), whether the cross section is volume-normalized.
             - **volume** (``float``, optional), volume for volume normalization.
 
@@ -146,14 +146,14 @@ class Xs:
         `nerea.Xs`"""
         if not self.volume_normalized:
             self.data /= self.volume
-        if not self.mass_normalized:
+        if not self.atomic_mass_normalized:
             idx = self.data.index.copy()
             self.data = _make_df(*ratio_v_u(self.data, ATOMIC_MASS),
                                  relative=False)[['value', 'uncertainty']
                                                  ].dropna()
             self.data.index = idx
         self.volume_normalized = True
-        self.mass_normalized = True
+        self.atomic_mass_normalized = True
         return self
 
 

--- a/nerea/experimental.py
+++ b/nerea/experimental.py
@@ -999,7 +999,7 @@ class SpectralIndex(_Experimental):
                 nuc_dec_from_file : dict[str, str] = None,
                 numerator_kwargs: dict={},
                 denominator_kwargs: dict={},
-                mass_normalized: bool=False) -> pd.DataFrame:
+                atomic_mass_normalized: bool=False) -> pd.DataFrame:
         """
         `nerea.SpectralIndex.process()`
         -------------------------------
@@ -1075,7 +1075,7 @@ class SpectralIndex(_Experimental):
             - ``self.pulse_height_spectrum.get_max()``
                 - **fst_ch** (``int | str``): channel to start max search or max search method.
 
-        **mass_normalized** : ``bool``, optional
+        **atomic_mass_normalized** : ``bool``, optional
             defines whether the result is the ratio of fission rates or of
             fission rates per unit mass.
             Default is ``False``.
@@ -1091,7 +1091,7 @@ class SpectralIndex(_Experimental):
         for impurities are mass-normalized (nerea.Xs.normalized). Then the processed 
         spectral index result is multiplied by the ratio between numerator and denominator
         atomic mass to be consistent with the definition of one-group cross section ratio.
-        Else the ``mass_normalized`` argument should be used passing consistent one group
+        Else the ``atomic_mass_normalized`` argument should be used passing consistent one group
         cross sections for impurity correction."""
         if numerator_kwargs.get('verbose', False):
             logger.info("PROCESSING SPECTRAL INDEX NUMERATOR.")
@@ -1119,7 +1119,10 @@ class SpectralIndex(_Experimental):
         # atomic mass ratio for EM renormalization
         # see docstring note
         # assumed to have no uncertainty
-        if not mass_normalized:
+        if not atomic_mass_normalized:
+            # I multiply numerator and denominator by A to
+            # allow for comparison with Serpent fission
+            # rate tally directly
             an = ATOMIC_MASS.loc[self.numerator.deposit_id].value 
             ad = ATOMIC_MASS.loc[self.denominator.deposit_id].value 
             mass_ratio = an / ad

--- a/tests/test_Comparison.py
+++ b/tests/test_Comparison.py
@@ -200,7 +200,7 @@ def test_compute_si(sample_si_ce):
                                   sample_si_ce.compute(
                                       numerator_kwargs={'raw_integral': False, 'renormalize': False},
                                       denominator_kwargs={'raw_integral': False, 'renormalize': False},
-                                      mass_normalized=True),
+                                      atomic_mass_normalized=True),
                                   check_exact=False, atol=0.00001)
     # check that sum(VAR_PORT) == uncertainty **2
     np.testing.assert_almost_equal(expected_df[[c for c in expected_df.columns if c.startswith("VAR_PORT")]].sum(axis=1).iloc[0],
@@ -234,7 +234,7 @@ def test_minus_one_per_cent(sample_si_ce):
                                   sample_si_ce.minus_one_percent(
                                       numerator_kwargs={'raw_integral': False, 'renormalize': False},
                                       denominator_kwargs={'raw_integral': False, 'renormalize': False},
-                                      mass_normalized=True),
+                                      atomic_mass_normalized=True),
                                   check_exact=False, atol=0.00001)
     # check that sum(VAR_PORT) == uncertainty **2
     np.testing.assert_almost_equal(expected_df[[c for c in expected_df.columns if c.startswith("VAR_PORT")]].sum(axis=1).iloc[0],

--- a/tests/test_SpectralIndex.py
+++ b/tests/test_SpectralIndex.py
@@ -83,7 +83,7 @@ def synthetic_one_g_xs_data():
                          'U238': [0.9, 0.003], 'U235': [0.6, 0.004]}).T.reset_index()
     data.columns = ['nuclide', 'value', 'uncertainty']
     data = data.set_index('nuclide')
-    return Xs(data, mass_normalized=True, volume_normalized=True)
+    return Xs(data, atomic_mass_normalized=True, volume_normalized=True)
 
 def test_deposit_ids(si):
     assert si.deposit_ids == ['U238', 'U235']
@@ -147,13 +147,13 @@ def test_process(si):
     pd.testing.assert_frame_equal(expected_df,
                                   si.process(numerator_kwargs={'raw_integral': False, 'renormalize': False},
                                              denominator_kwargs={'raw_integral': False, 'renormalize': False},
-                                             mass_normalized=True),
+                                             atomic_mass_normalized=True),
                                   check_exact=False, atol=0.00001)
     # check that sum(VAR_PORT) == uncertainty **2
     np.testing.assert_almost_equal(expected_df[[c for c in expected_df.columns if c.startswith("VAR_PORT")]].sum(axis=1).iloc[0],
                                    expected_df['uncertainty'].iloc[0] **2, decimal=5)
     
-    # test mass_normalized=False
+    # test atomic_mass_normalized=False
     m = 238.050783 / 235.043923
     expected_df = pd.DataFrame({'value': 1.0 * m,
                                 'uncertainty': 0.06588712284729072 * m,
@@ -170,7 +170,7 @@ def test_process(si):
     pd.testing.assert_frame_equal(expected_df,
                                   si.process(numerator_kwargs={'raw_integral': False, 'renormalize': False},
                                              denominator_kwargs={'raw_integral': False, 'renormalize': False},
-                                             mass_normalized=False),
+                                             atomic_mass_normalized=False),
                                   check_exact=False, atol=0.00001)
     # check that sum(VAR_PORT) == uncertainty **2
     np.testing.assert_almost_equal(expected_df[[c for c in expected_df.columns if c.startswith("VAR_PORT")]].sum(axis=1).iloc[0],
@@ -215,7 +215,7 @@ def test_compute_with_correction(si, synthetic_one_g_xs_data):
     nerea_ = si.process(synthetic_one_g_xs_data,
                         numerator_kwargs={'raw_integral': False, 'renormalize': False},
                         denominator_kwargs={'raw_integral': False, 'renormalize': False},
-                        mass_normalized=True)
+                        atomic_mass_normalized=True)
     np.testing.assert_equal(data.index.values, nerea_.index.values)
     np.testing.assert_equal(data.columns.values, nerea_[['value', 'uncertainty', 'uncertainty [%]']].columns.values)
     np.testing.assert_almost_equal(data['value'].values, nerea_['value'].values, decimal=4)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -10,20 +10,20 @@ def test_xs_copy():
     xs = Xs(pd.DataFrame({"value": [1., 2.], "uncertainty": [1., 2.]},
                          index=["A", "B"]),
             volume=2.,
-            mass_normalized=True,
+            atomic_mass_normalized=True,
             volume_normalized=True)
     xsc = xs.copy()
     pd.testing.assert_frame_equal(xs.data, xsc.data)
     assert xsc.volume == xs.volume
     assert xsc.volume_normalized == xs.volume_normalized
-    assert xsc.mass_normalized == xs.mass_normalized
+    assert xsc.atomic_mass_normalized == xs.atomic_mass_normalized
 
 def test_xs_normalized():
     start_data = pd.DataFrame({"value": [1., 2.], "uncertainty": [1., 2.]},
                          index=["U235", "U238"])
     xs = Xs(start_data,
             volume=1,
-            mass_normalized=False,
+            atomic_mass_normalized=False,
             volume_normalized=False)
     mass_norm = pd.DataFrame({"value": [1. / ATOMIC_MASS.loc['U235', 'value'],
                                         2. / ATOMIC_MASS.loc['U238', 'value']],
@@ -33,13 +33,13 @@ def test_xs_normalized():
     # full normalization volume = 1
     xsc = xs.copy().normalized
     pd.testing.assert_frame_equal(xsc.data[['value', 'uncertainty']], mass_norm)
-    assert xsc.mass_normalized == True
+    assert xsc.atomic_mass_normalized == True
     assert xsc.volume_normalized == True
     # full normalization volume = 2
     xs.volume = 2.
     xsc = xs.copy().normalized
     pd.testing.assert_frame_equal(xsc.data[['value', 'uncertainty']], mass_norm / 2.)
-    assert xsc.mass_normalized == True
+    assert xsc.atomic_mass_normalized == True
     assert xsc.volume_normalized == True
     # mass normalization only (even with volume = 2)
     xs.volume_normalized = True
@@ -47,6 +47,6 @@ def test_xs_normalized():
     pd.testing.assert_frame_equal(xsc.data[['value', 'uncertainty']], mass_norm)
     assert xsc.volume_normalized == True
     # no normalization when both normalizations are set to True
-    xs.mass_normalized = True
+    xs.atomic_mass_normalized = True
     xsc = xs.copy().normalized
     pd.testing.assert_frame_equal(xsc.data[['value', 'uncertainty']], start_data)


### PR DESCRIPTION
kwarg `mass_normalized` for `nerea.SpectralIndex.process` and `nerea.Xs.__init__` adapted to `atomic_mass_normalized` for readability.